### PR TITLE
Fixes #308 Mac dock icon staying in the dock after auto launch

### DIFF
--- a/AdGuard/AdGuard Login Helper/main.m
+++ b/AdGuard/AdGuard Login Helper/main.m
@@ -33,7 +33,7 @@ int main(int argc, const char * argv[]) {
 
                 NSError *lError = nil;
                 NSRunningApplication *app = [[NSWorkspace sharedWorkspace] launchApplicationAtURL:url
-                                                                                          options:0
+                                                                                          options:NSWorkspaceLaunchWithoutAddingToRecents
                                                                                     configuration:@{NSWorkspaceLaunchConfigurationEnvironment:
                                                                                                         @{@"LAUNCHED_AT_LOGIN": @"1"}}
                                                                                             error:&lError];


### PR DESCRIPTION
See issue #308 for detailed issue description.

This PR adds the "NSWorkspaceLaunchWithoutAddingToRecents" option to the login helper, so the AdGuard dock icon is not added to the recently used applications of the dock on startup, but instead disappears from the dock after starting, like the expected behaviour when starting in background.