### PR TITLE
Fix issue #308 again, AdGuard app icon staying in dock

### DIFF
--- a/AdGuard/AdGuard Login Helper/main.m
+++ b/AdGuard/AdGuard Login Helper/main.m
@@ -33,7 +33,7 @@ int main(int argc, const char * argv[]) {
                 NSError *error = nil;
                 [NSWorkspace.sharedWorkspace openURLs:@[urlToOpen]
                                  withApplicationAtURL:url
-                                              options:0
+                                              options:NSWorkspaceLaunchWithoutAddingToRecents
                                         configuration:@{}
                                                 error:&error];
                 


### PR DESCRIPTION
Add the `NSWorkspaceLaunchWithoutAddingToRecents` option to the login helper URL call to prevent the AdGuard app icon staying in the dock on auto-start. See the issue for more details, it's still reproducible with latest v1.11.15.

Before (with options: 0):

![1](https://github.com/AdguardTeam/AdGuardForSafari/assets/15860314/d9c0709c-abf9-47be-93fa-764be8192126)

After the changes from this PR:

![2](https://github.com/AdguardTeam/AdGuardForSafari/assets/15860314/06493e74-8708-4381-806b-04b7eee7d977)
